### PR TITLE
README: keep https://toof.jp/icon.png stable for external users

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,6 @@
 # toof-jp.github.io
 https://toof.jp  
 https://toof-jp.github.io
+
+## Notes
+- The URL `https://toof.jp/icon.png` is referenced by external services/tools. Keep this URL stable over time. If you must remove, move, or rename it, ensure the original URL continues to work (e.g., via a permanent redirect).


### PR DESCRIPTION
Add an English note clarifying that the icon URL (https://toof.jp/icon.png) is referenced by external services/tools and must remain stable over time. If it must be moved or renamed, keep the original URL working via a permanent redirect.